### PR TITLE
set main file bower as non minified

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperform",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "homepage": "https://github.com/hyperform/hyperform",
   "authors": [
     "Manuel Strehl"

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Manuel Strehl"
   ],
   "description": "Capture form validation back from the browser",
-  "main": "dist/hyperform.min.js",
+  "main": "dist/hyperform.js",
   "moduleType": [
     "amd",
     "es6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperform",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Capture form validation back from the browser",
   "main": "dist/hyperform.cjs.js",
   "jsnext:main": "src/hyperform.js",


### PR DESCRIPTION
hi guys!

has an invalid meta in bower.json, the main file cant be minified

![screen shot 2017-01-06 at 15 34 42](https://cloud.githubusercontent.com/assets/876227/21726846/a072c70c-d425-11e6-94c5-81d1dc37079d.png)

so, I just change the main file to a non minified `dist/hyperform.js`

this allow developers with gulp/grunt or whatever, define what do with the main files (like minification)